### PR TITLE
chore: update supported obsidian version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 main.js
+data.json
+
 # Logs
 logs
 *.log

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "id": "obsidian-gitlab-plugin",
   "name": "GitLab Plugin",
   "version": "0.0.1",
-  "minAppVersion": "0.15.0",
+  "minAppVersion": "1.5.0",
   "description": "A plugin to integrate GitLab embeds into Obsidian.",
   "author": "Olivier Goulet",
   "authorUrl": "https://github.com/oliviergoulet5",
-  "isDesktopOnly": true
+  "isDesktopOnly": false
 }


### PR DESCRIPTION
This PR sets the minimum Obsidian verison to 1.5.0 and adds data.json to .gitignore.