### PR TITLE
fix: change obsidian id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "obsidian-gitlab-embeds",
+  "name": "obsidian-gitlab-plugin",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-gitlab-embeds",
+      "name": "obsidian-gitlab-plugin",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "obsidian-gitlab-embeds",
+  "name": "obsidian-gitlab-plugin",
   "version": "1.0.0",
   "main": "main.js",
   "type": "module",


### PR DESCRIPTION
This way, the Obsidian plugin should be more appropriately named.